### PR TITLE
Refactor library to have option to not exit on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ storageRules.test('<description>'/* description for logging */, {
 }).shouldFail(); // this test case should fail
 
 // validate the tests
-validateRuleSuite(storageRules, { logging: true });
+validateRuleSuite(storageRules, { logging: true, exitOnFailure: true });
 
 ```
 

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function assertIssues(res) {
 	return res;
 }
 
-function validateRuleSuite(suite, options) {
+function validateRuleSuite(suite, options = {}) {
 	return requireAuth({}).then(() =>
 		api.request(
 			"POST",

--- a/index.js
+++ b/index.js
@@ -94,6 +94,10 @@ function assertIssues(res) {
 }
 
 function validateRuleSuite(suite, options = {}) {
+	if (typeof options.exitOnFailure === 'undefined') {
+		options.exitOnFailure = true;
+	}
+
 	return requireAuth({}).then(() =>
 		api.request(
 			"POST",

--- a/index.js
+++ b/index.js
@@ -73,12 +73,7 @@ function assertResults(suite, results, options) {
 	});
 
 	if (exitError) {
-		log(
-			console.error,
-			'Some tests failed',
-			options.logging
-		);
-		process.exit(1);
+		throw new Error('Some tests failed');
 	}
 }
 
@@ -107,11 +102,20 @@ function validateRuleSuite(suite, options) {
 		)).then(assertIssues)
 		.then(res => {
 			return res.body.testResults;
-		}).then(results =>
-			assertResults(suite, results, options))
-		.catch(err => {
-			log(console.error, clc.red(err.message), true);
-			process.exit(1);
+		}).then(results => {
+			try {
+				assertResults(suite, results, options);
+			} catch (err) {
+				return Promise.reject(err);
+			}
+		}).catch(err => {
+			log(console.error, clc.red(err.message), options.logging);
+
+			if (options.exitOnFailure) {
+				process.exit(1);
+			}
+
+			return Promise.reject(err);
 		});
 }
 


### PR DESCRIPTION
First and foremost, thanks for the work put into this library :smile: 

# Description

The usage of `process.exit(1)` makes this library more of a stand-alone library that cannot be integrated to test suites such as Jest. I've refactored mainly the `validateRuleSuite` to reject on errors instead of exiting the entire process since this will cause Jest to exit on failures, making TDD impossible.

# Changes

- Remove error logging and process exit call from `assertResults` function
- Add an `exitOnFailure` option to the `validateRuleSuite` function

# Breaking Changes

As much as possible, I've tried to avoid breaking changes that will affect people down the line. However, I have made some changes:

1. Function `validateRuleSuite` now respects `options.logging` when reporting errors
2. Function `validateRuleSuite` would have had `options.exitOnFailure` default to `true` while it now defaults to `false` seeing as there's no defaults set for `options`

The following patch-set still has breaking changes as the documentation did not previously mention `exitOnFailure`:

```diff
diff --git a/index.js b/index.js
index 32ae0e5..9b62aa0 100644
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function assertIssues(res) {
        return res;
 }
 
-function validateRuleSuite(suite, options = {}) {
+function validateRuleSuite(suite, options = { logging: false, exitOnFailure: true }) {
        return requireAuth({}).then(() =>
                api.request(
                        "POST",
```

The following however should ensure that there are no breaking changes:

```diff
diff --git a/index.js b/index.js
index 32ae0e5..e31aa6e 100644
--- a/index.js
+++ b/index.js
@@ -94,6 +94,10 @@ function assertIssues(res) {
 }
 
 function validateRuleSuite(suite, options = {}) {
+       if (typeof options.exitOnFailure === 'undefined') {
+               options.exitOnFailure = true;
+       }
+
        return requireAuth({}).then(() =>
                api.request(
                        "POST",
```

I decided to include neither of these patches to leave it to your discretion :smile: 